### PR TITLE
feat: add expense deletion route

### DIFF
--- a/routes/expenses.js
+++ b/routes/expenses.js
@@ -161,6 +161,23 @@ router.get('/expenses', async (_req, res) => {
   }
 });
 
+// DELETE /api/expenses/:id
+router.delete('/expenses/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const deleted = await Expense.findByIdAndDelete(id);
+
+    if (!deleted) {
+      return res.status(404).json({ message: 'Expense not found' });
+    }
+
+    return res.status(200).json({ message: 'Expense deleted successfully' });
+  } catch (err) {
+    console.error('Expense delete error:', err);
+    return res.status(500).json({ message: 'Internal Server Error' });
+  }
+});
+
 
 
 export default router;


### PR DESCRIPTION
## Summary
- support deleting expenses by id via DELETE /api/expenses/:id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cb188712083279185d2794f626b16