### PR TITLE
Implement session-based authentication for API

### DIFF
--- a/models/user.model.js
+++ b/models/user.model.js
@@ -4,9 +4,10 @@ const userSchema = new mongoose.Schema(
     {
       name:         { type: String, required: true, trim: true },
       passwordHash: { type: String, required: true },
-      relation:     { type: String, required: true }
+      relation:     { type: String, required: true },
+      isAdmin:      { type: Boolean, default: false }
     },
     { timestamps: true }
-  ); 
+  );
 
 export default mongoose.model('User', userSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "connect-mongo": "^5.1.0",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "express-session": "^1.18.1",
         "mongoose": "^8.13.2"
       }
     },
@@ -120,6 +122,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -139,6 +153,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -240,6 +260,23 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/connect-mongo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.1.0.tgz",
+      "integrity": "sha512-xT0vxQLqyqoUTxPLzlP9a/u+vir0zNkhiy9uAdHjSCcUUf7TS5b55Icw8lVyYFxfemP3Mf9gdwUOgeF3cxCAhw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "kruptein": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "express-session": "^1.17.1",
+        "mongodb": ">= 5.1.0 < 7"
+      }
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -473,6 +510,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
@@ -760,6 +837,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/kruptein": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.0.8.tgz",
+      "integrity": "sha512-0CyalFA0Cjp3jnziMp0u1uLZW2/ouhQ0mEMfYlroBXNe86na1RwAuwBcdRAegeWZNMfQy/G5fN47g/Axjtqrfw==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1.js": "^5.4.1"
+      },
+      "engines": {
+        "node": ">8"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -840,6 +929,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -1122,6 +1217,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1193,6 +1297,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -1539,6 +1652,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "description": "",
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "connect-mongo": "^5.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "express-session": "^1.18.1",
     "mongoose": "^8.13.2"
   },
   "type": "module"

--- a/routes/expenses.js
+++ b/routes/expenses.js
@@ -1,19 +1,151 @@
 import { Router } from "express";
+import bcrypt from "bcrypt";
 import Expense from "../models/expense.model.js";
-import User from "../models/user.model.js" 
-import bcrypt from 'bcrypt';
-import Config from "../models/config.model.js"
+import User from "../models/user.model.js";
+import Config from "../models/config.model.js";
 
 const router = Router();
 
-// POST /api/expenses
-router.post("/addExpenses", async (req, res) => {
-  const doc = await Expense.create(req.body);
-  res.status(201).json(doc);
+const THIRTY_DAYS_MS = 1000 * 60 * 60 * 24 * 30;
+const SESSION_COOKIE_NAME = process.env.SESSION_COOKIE_NAME || "mw.sid";
+const isProduction = process.env.NODE_ENV === "production";
+const CLEAR_COOKIE_OPTIONS = {
+  path: "/",
+  httpOnly: true,
+  sameSite: isProduction ? "none" : "lax",
+  secure: isProduction,
+};
+
+const buildUserResponse = (user) => ({
+  id: user._id,
+  name: user.name,
+  relation: user.relation,
+  isAdmin: Boolean(user.isAdmin),
 });
 
+const startUserSession = (req, user) =>
+  new Promise((resolve, reject) => {
+    req.session.regenerate((regenerateErr) => {
+      if (regenerateErr) {
+        return reject(regenerateErr);
+      }
 
-// GET /api/expenses (optionally filtered by query‑params)
+      const payload = buildUserResponse(user);
+      req.session.userId = user._id.toString();
+      req.session.user = payload;
+      req.session.cookie.maxAge = THIRTY_DAYS_MS;
+
+      req.session.save((saveErr) => {
+        if (saveErr) {
+          return reject(saveErr);
+        }
+
+        resolve(payload);
+      });
+    });
+  });
+
+const ensureAuthenticated = (req, res, next) => {
+  if (!req.session?.userId) {
+    return res.status(401).json({ message: "Authentication required." });
+  }
+
+  next();
+};
+
+router.post("/auth/register", async (req, res) => {
+  try {
+    const { name, password, relation } = req.body;
+
+    if (!name?.trim() || !password || !relation?.trim()) {
+      return res.status(400).json({ message: "All fields are required." });
+    }
+
+    const normalizedName = name.trim();
+    const normalizedRelation = relation.trim();
+    const exists = await User.exists({ name: normalizedName });
+    if (exists) {
+      return res.status(409).json({ message: "User already registered." });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 12);
+    const newUser = await User.create({
+      name: normalizedName,
+      passwordHash,
+      relation: normalizedRelation,
+    });
+
+    const payload = await startUserSession(req, newUser);
+    return res.status(201).json(payload);
+  } catch (err) {
+    console.error("Registration error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
+  }
+});
+
+router.post("/auth/login", async (req, res) => {
+  const { name, email, password } = req.body;
+  const identifier = name?.trim() || email?.trim();
+
+  if (!identifier || !password) {
+    return res
+      .status(400)
+      .json({ message: "Name and password are required." });
+  }
+
+  try {
+    const user = await User.findOne({ name: identifier });
+    if (!user) {
+      return res.status(401).json({ message: "Invalid credentials." });
+    }
+
+    const passwordMatch = await bcrypt.compare(password, user.passwordHash);
+    if (!passwordMatch) {
+      return res.status(401).json({ message: "Invalid credentials." });
+    }
+
+    const payload = await startUserSession(req, user);
+    return res.status(200).json(payload);
+  } catch (err) {
+    console.error("Login error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
+  }
+});
+
+router.post("/auth/logout", (req, res) => {
+  const finalizeLogout = () => {
+    res.clearCookie(SESSION_COOKIE_NAME, CLEAR_COOKIE_OPTIONS);
+    return res.status(200).json({ message: "Logged out" });
+  };
+
+  if (!req.session) {
+    return finalizeLogout();
+  }
+
+  req.session.destroy((err) => {
+    if (err) {
+      console.error("Logout error:", err);
+      return res.status(500).json({ message: "Failed to log out." });
+    }
+
+    return finalizeLogout();
+  });
+});
+
+router.use(ensureAuthenticated);
+
+// POST /api/expenses
+router.post("/addExpenses", async (req, res) => {
+  try {
+    const doc = await Expense.create(req.body);
+    return res.status(201).json(doc);
+  } catch (err) {
+    console.error("Expense create error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
+  }
+});
+
+// GET /api/expenses (optionally filtered by query-params)
 router.get("/", async (req, res) => {
   const {
     startDate,
@@ -23,15 +155,21 @@ router.get("/", async (req, res) => {
     mode,
   } = req.query;
 
-  const query = {};
-  if (startDate && endDate)
-    query.date = { $gte: new Date(startDate), $lte: new Date(endDate) };
-  if (category && category !== "all-categories")     query.category    = category;
-  if (subcategory && subcategory !== "all-subcategories") query.subcategory = subcategory;
-  if (mode && mode !== "all-modes")                 query.mode        = mode;
+  try {
+    const query = {};
+    if (startDate && endDate)
+      query.date = { $gte: new Date(startDate), $lte: new Date(endDate) };
+    if (category && category !== "all-categories") query.category = category;
+    if (subcategory && subcategory !== "all-subcategories")
+      query.subcategory = subcategory;
+    if (mode && mode !== "all-modes") query.mode = mode;
 
-  const docs = await Expense.find(query).sort({ date: -1 });
-  res.json(docs);
+    const docs = await Expense.find(query).sort({ date: -1 });
+    return res.json(docs);
+  } catch (err) {
+    console.error("Expenses fetch error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
+  }
 });
 
 // GET /api/expenses/summary?type=weekly|monthly
@@ -40,144 +178,85 @@ router.get("/summary", async (req, res) => {
   if (!["weekly", "monthly"].includes(type))
     return res.status(400).json({ error: "type must be weekly or monthly" });
 
-  const now = new Date();
-  const first =
-    type === "weekly"
-      ? new Date(now.setDate(now.getDate() - (now.getDay() || 7) + 1)) // Mon
-      : new Date(now.getFullYear(), now.getMonth(), 1);
-
-  const sum = await Expense.aggregate([
-    { $match: { date: { $gte: first } } },
-    { $group: { _id: null, total: { $sum: "$amount" } } },
-  ]);
-
-  res.json({ total: sum[0]?.total || 0 });
-});
-
-router.post('/auth/register', async (req, res) => {
   try {
-    const { name, password, relation } = req.body;
+    const now = new Date();
+    const first =
+      type === "weekly"
+        ? new Date(now.setDate(now.getDate() - (now.getDay() || 7) + 1)) // Mon
+        : new Date(now.getFullYear(), now.getMonth(), 1);
 
-    if (!name || !password || !relation) {
-      return res.status(400).json({ message: 'All fields are required.' });
-    }
+    const sum = await Expense.aggregate([
+      { $match: { date: { $gte: first } } },
+      { $group: { _id: null, total: { $sum: "$amount" } } },
+    ]);
 
-    const exists = await User.exists({ name });
-    if (exists) {
-      return res.status(409).json({ message: 'User already registered.' });
-    }
-
-    const passwordHash = await bcrypt.hash(password, 12);
-    const newUser      = await User.create({ name, passwordHash, relation });
-
-    return res.status(201).json({
-      id:        newUser._id,
-      name:      newUser.name,
-      relation:  newUser.relation,
-      createdAt: newUser.createdAt
-    });
+    return res.json({ total: sum[0]?.total || 0 });
   } catch (err) {
-    console.error('Registration error:', err);
-    res.status(500).json({ message: 'Internal Server Error' });
+    console.error("Expenses summary error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 });
 
-router.post('/auth/login', async (req, res) => {
-  const { email, password } = req.body;
-  console.log("email: "+email+" password "+password);
-  if (!email || !password)
-    return res.status(400).json({ message: 'Email and password are required.' });
-
-  try {
-    const user = await User.findOne({ name: email });
-    const passwordMatch = user && await bcrypt.compare(password, user.passwordHash);
-    console.log("user "+user);
-    if (!passwordMatch) {
-      return res.status(401).json({ message: 'Invalid credentials.' });
-    }
-
-    return res.status(200).json({
-      user: {
-        id: user._id,
-        name: user.name,
-        email: user.email,
-        relation: user.relation
-      }
-    });
-  } catch (err) {
-    console.error('Login error:', err);
-    res.status(500).json({ message: 'Internal Server Error' });
-  }
-});
-
-router.get('/config', async (_req, res) => {
+router.get("/config", async (_req, res) => {
   try {
     let config = await Config.findOne();
-    console.log("config "+config);
-    // If no config document exists, seed a default one
     if (!config) {
       config = await Config.create({});
-      console.log('Created default config document');
+      console.log("Created default config document");
     }
 
     return res.status(200).json(config);
   } catch (err) {
-    console.error('Config fetch error:', err);
-    res.status(500).json({ message: 'Internal Server Error' });
+    console.error("Config fetch error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 });
 
-router.put('/config', async (req, res) => {
-  const payload = req.body;                    // ExpenseConfig sent by React
-  console.log("payload "+payload);
+router.put("/config", async (req, res) => {
+  const payload = req.body; // ExpenseConfig sent by React
   try {
-    // upsert:true → create if none exists; new:true → return updated doc
     const updatedConfig = await Config.findOneAndUpdate(
       {},
-      { ...payload, updatedBy: 'api' },         // merge / override fields
+      { ...payload, updatedBy: "api" }, // merge / override fields
       { new: true, upsert: true, runValidators: true }
     );
     return res.status(200).json(updatedConfig);
   } catch (err) {
-    console.error('Config update error:', err);
-    res.status(500).json({ message: 'Internal Server Error' });
+    console.error("Config update error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 });
 
-router.get('/expenses', async (_req, res) => {
+router.get("/expenses", async (_req, res) => {
   try {
     let expenses = await Expense.find();
-    console.log("expenses "+expenses);
-    // If no config document exists, seed a default one
     if (!expenses) {
       expenses = await Config.create({});
-      console.log('Created default expenses document');
+      console.log("Created default expenses document");
     }
 
     return res.status(200).json(expenses);
   } catch (err) {
-    console.error('expenses fetch error:', err);
-    res.status(500).json({ message: 'Internal Server Error' });
+    console.error("Expenses fetch error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 });
 
 // DELETE /api/expenses/:id
-router.delete('/expenses/:id', async (req, res) => {
+router.delete("/expenses/:id", async (req, res) => {
   try {
     const { id } = req.params;
     const deleted = await Expense.findByIdAndDelete(id);
 
     if (!deleted) {
-      return res.status(404).json({ message: 'Expense not found' });
+      return res.status(404).json({ message: "Expense not found" });
     }
 
-    return res.status(200).json({ message: 'Expense deleted successfully' });
+    return res.status(200).json({ message: "Expense deleted successfully" });
   } catch (err) {
-    console.error('Expense delete error:', err);
-    return res.status(500).json({ message: 'Internal Server Error' });
+    console.error("Expense delete error:", err);
+    return res.status(500).json({ message: "Internal Server Error" });
   }
 });
-
-
 
 export default router;

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ import express from "express";
 import cors from "cors";
 import mongoose from "mongoose";
 import dotenv from "dotenv";
+import session from "express-session";
+import MongoStore from "connect-mongo";
 import expenseRoutes from "./routes/expenses.js";
 
 dotenv.config();
@@ -10,8 +12,40 @@ await mongoose.connect(process.env.MONGODB_URI);
 console.log("✅  MongoDB connected");
 
 const app = express();
-app.use(cors());
+const isProduction = process.env.NODE_ENV === "production";
+const THIRTY_DAYS_MS = 1000 * 60 * 60 * 24 * 30;
+const SESSION_COOKIE_NAME = process.env.SESSION_COOKIE_NAME || "mw.sid";
+
+app.set("trust proxy", 1);
+
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN
+      ? process.env.CORS_ORIGIN.split(",").map((origin) => origin.trim())
+      : true,
+    credentials: true,
+  })
+);
 app.use(express.json());
+app.use(
+  session({
+    name: SESSION_COOKIE_NAME,
+    secret: process.env.SESSION_SECRET || "change-me",
+    resave: false,
+    saveUninitialized: false,
+    rolling: true,
+    store: MongoStore.create({
+      mongoUrl: process.env.MONGODB_URI,
+      ttl: THIRTY_DAYS_MS / 1000,
+    }),
+    cookie: {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: isProduction ? "none" : "lax",
+      maxAge: THIRTY_DAYS_MS,
+    },
+  })
+);
 
 app.use("/api", expenseRoutes);
 


### PR DESCRIPTION
## Summary
- add Mongo-backed session management with 30-day cookies and credentialed CORS support
- update auth routes to issue persistent sessions, expose logout, and return the expected user payload
- require authenticated sessions across expense and config endpoints

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cff64e8b248327b2970c24ce84d5b9